### PR TITLE
Move tests to run in MacOS 12

### DIFF
--- a/.github/actions/install_packer/action.yml
+++ b/.github/actions/install_packer/action.yml
@@ -1,5 +1,6 @@
 name: Install Packer
-description: Installs the packerio executable and its attendant tools to ~/bin
+description: Installs the packerio executable and its attendant tools to /usr/local/bin
+  for Ubuntu hosts
 inputs:
   version:
     description: Version of Packer to install

--- a/.github/actions/install_virtualbox/action.yml
+++ b/.github/actions/install_virtualbox/action.yml
@@ -1,0 +1,9 @@
+name: Install virtualbox on Mac
+description: Installs virtualbox on Mac runners
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -exo pipefail
+        brew install virtualbox vagrant

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           ubuntu = json.loads('${{ steps.collection.outputs.tox-envs }}')
           macos  = json.loads('${{ steps.vagrant.outputs.tox-envs }}')
           ub_zip = [{'os': 'ubuntu-latest', 'scenario': u} for u in ubuntu]
-          mac_zip = [{'os': 'macos-10.15', 'scenario': m} for m in macos]
+          mac_zip = [{'os': 'macos-12', 'scenario': m} for m in macos]
           print("::set-output name=scenarios::" + json.dumps(ub_zip + mac_zip))
 
   lint:
@@ -83,5 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/install_virtualbox
+        if: startsWith(matrix.scenarios.os, 'macos')
       - name: Run scenario
         run: tox -e "${{ matrix.scenarios.scenario }}"


### PR DESCRIPTION
MacOS 12 hosted runners are now in Beta. Github actions folk claim that
installing VirtualBox (and, therefore, vagrant) is no longer a
difficulty, so we will move to using it for our VM-based testing