### PR TITLE
Unified Build Time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       distros: ${{ steps.distros.outputs.distros }}
+      build: ${{ steps.time.outputs.time }}
     steps:
       - uses: actions/checkout@v3
       - name: Discover boxes
@@ -22,6 +23,11 @@ jobs:
           set -eo pipefail
           distros=$(ls distros/*.hcl{,.sh} | jq -cRs 'split("\n") | [ .[] | if length > 0 then . else empty end ]')
           echo "::set-output name=distros::${distros}"
+      - name: Find timestamp for versioning
+        id: time
+        uses: nanzm/get-time-action@v1.1
+        with:
+          format: 'YYYY.MM.DD.HH'
 
   build:
     name: Build box
@@ -64,7 +70,7 @@ jobs:
           # Strip .sh if it is a dynamic one
           file="$(printf "${{ matrix.distro }}" | sed -E -e 's/^(.*).sh$/\1/')"
           # Add a retry in case something bogus like a network failure happens
-          packer build -only="${{ matrix.builder }}" -var-file="${file}" -var "qemu_accelerator=tcg" ${{ github.event_name != 'release' && '-except=upload' || '' }} sources
+          packer build -only="${{ matrix.builder }}" -var-file="${file}" -var "qemu_accelerator=tcg" -var "build=${{ needs.collect.outputs.build }}" ${{ github.event_name != 'release' && '-except=upload' || '' }} sources
         env:
           VAGRANT_CLOUD_TOKEN: ${{ secrets.VAGRANT_CLOUD_TOKEN }}
           PACKER_LOG: ${{ contains(matrix.needs_timeout, matrix.distro) && '0' || '0' }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ output_*
 *.box
 *.iso
 .vagrant
-serial-output
+serial-output*
 grub.cfg
 isolinux.cfg
 

--- a/ansible/roles/virtualbox/tasks/main.yml
+++ b/ansible/roles/virtualbox/tasks/main.yml
@@ -25,7 +25,8 @@
     enabled: true
   loop: "{{ virtualbox_services }}"
 
-- when: virtualbox_from_iso
+- name: Run commands to install from ISO
+  when: virtualbox_from_iso
   block:
     - name: Mount iso file
       become: true

--- a/sources/build.pkr.hcl
+++ b/sources/build.pkr.hcl
@@ -34,7 +34,7 @@ build {
 			name = "upload"
 			access_token = var.vagrant_cloud_token
 			box_tag = "boxen/${local.name}"
-			version = local.build
+			version = var.build
 			version_description = local.description
 		}
 	}

--- a/sources/inputs.pkr.hcl
+++ b/sources/inputs.pkr.hcl
@@ -44,14 +44,18 @@ variable "vagrant_cloud_token" {
 	default = env("VAGRANT_CLOUD_TOKEN")
 }
 
+variable "build" {
+	type = string
+	default = "0.1"
+}
+
 locals {
 	name = "${var.distro}-${var.version}-${var.arch}"
-	build = formatdate("YYYYMMDDhh", timestamp())
 	description = templatefile("../README.box.md", {
 		distro = var.distro
 		arch = var.arch
 		version = var.version
-		build = local.build
+		build = var.build
 	})
 
 	cpus = 2


### PR DESCRIPTION
Currently, each build will get a time based on when it specifically started, rather than when the entire release was started. This is  undesirable, as we would like builds for all of our providers to share the same version number when they are build from the same release tag. This unifies that code.